### PR TITLE
fix: revert string as a YAML comment

### DIFF
--- a/src/backend/loyalty/template.yaml
+++ b/src/backend/loyalty/template.yaml
@@ -129,8 +129,8 @@ Resources:
       Value: !Sub "https://${LoyaltyApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
 
   #
-  Uncomment the following resources + AccessLogSetting to enable API Gateway Logs
-  [CAUTION] API Gateway can only have one IAM Role to push logs too, do not uncomment if you already have one
+  # Uncomment the following resources + AccessLogSetting to enable API Gateway Logs
+  # [CAUTION] API Gateway can only have one IAM Role to push logs too, do not uncomment if you already have one
   # 
   ApiGatewayCloudWatchRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Line 131-134 are not valid CloudFormation syntax. This commit reverts that string as a comment

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
